### PR TITLE
fix: chockadir should wait for the file write to finish

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,8 +88,7 @@ const processFiles = async () => {
       chokidar
         .watch(markdownPath, {
           awaitWriteFinish: {
-            stabilityThreshold: 2000,
-            pollInterval: 100
+            stabilityThreshold: 500
           }
         })
         .on('change', () => {

--- a/index.js
+++ b/index.js
@@ -86,7 +86,12 @@ const processFiles = async () => {
 
       console.log('Watching for changes...')
       chokidar
-        .watch(markdownPath)
+        .watch(markdownPath, {
+          awaitWriteFinish: {
+            stabilityThreshold: 2000,
+            pollInterval: 100
+          }
+        })
         .on('change', () => {
           processFiles().catch(error => {
             console.error(error)


### PR DESCRIPTION
We should wait for writes to finish before rendering. 

https://github.com/paulmillr/chokidar#performance
https://stackoverflow.com/questions/52214121/nodejs-printing-fs-readfile-data-after-chokidars-watcher-onchange-returns-an

Closes #15 