### PR TITLE
Add dependabot & notify-release github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -1,0 +1,15 @@
+name: notify-release
+on:
+  workflow_dispatch:
+    branches:
+      - master
+  schedule:
+    - cron: '30 8 * * *'
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify release
+        uses: nearform/github-action-notify-release@v1.2.2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adding CI steps to check on a daily basis:
* if there are any dependencies that can be upgraded
* if there are any commits older than 7 days that have not been released yet